### PR TITLE
Upgrading to the latest Kubectl version 1.5.x

### DIFF
--- a/redis-cluster.yml
+++ b/redis-cluster.yml
@@ -75,8 +75,8 @@ data:
 
     wait
 ---
-apiVersion: apps/v1alpha1
-kind: PetSet
+apiVersion: apps/v1beta1
+kind: StatefulSet
 metadata:
   name: redis-cluster
 spec:
@@ -87,7 +87,7 @@ spec:
       labels:
         app: redis-cluster
       annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
+        pod.alpha.kubernetes.io/initialized: "false"
         # NOTE: Init container must be idempotent
         # Add a baked-in Redis config file that enables cluster mode
         #pod.alpha.kubernetes.io/init-containers: '[


### PR DESCRIPTION
Based on the issue #1 to have the latest StatefulSet issue - https://github.com/sobotklp/kubernetes-redis-cluster/issues/1 , making this test after checking that 

RajRajen:kubernetes-redis-cluster rajrajen$ ./kubectl create -f redis-cluster.yml
statefulset "redis-cluster" created

RajRajen:kubernetes-redis-cluster rajrajen$ ./kubectl get pods
NAME                              READY     STATUS    RESTARTS   AGE
hello-minikube-3015430129-jslxl   1/1       Running   0          1h
redis-cluster-0                   1/1       Running   0          3m