### PR TITLE
fix(bootstrap-script): reverse PET_ORDINAL

### DIFF
--- a/etc/bootstrap-pod.sh
+++ b/etc/bootstrap-pod.sh
@@ -3,7 +3,7 @@ set -ex
 
 # Find which member of the Stateful Set this pod is running
 # e.g. "redis-cluster-0" -> "0"
-PET_ORDINAL=$(cat /etc/podinfo/pod_name | rev | cut -d- -f1)
+PET_ORDINAL=$(cat /etc/podinfo/pod_name | rev | cut -d- -f1 | rev)
 MY_SHARD=$(($PET_ORDINAL % $NUM_SHARDS))
 
 redis-server /conf/redis.conf &

--- a/redis-cluster.yml
+++ b/redis-cluster.yml
@@ -60,7 +60,7 @@ data:
 
     # Find which member of the Stateful Set this pod is running
     # e.g. "redis-cluster-0" -> "0"
-    PET_ORDINAL=$(cat /etc/podinfo/pod_name | rev | cut -d- -f1)
+    PET_ORDINAL=$(cat /etc/podinfo/pod_name | rev | cut -d- -f1 | rev)
     MY_SHARD=$(($PET_ORDINAL % $NUM_SHARDS))
 
     redis-server /conf/redis.conf &


### PR DESCRIPTION
For replica number more than 10 it cause problem because the `PET_ORDINAL` value is reversed.
for example `PET_ORDINAL` for pod `redis-cluster-12` is 21 but it should be 12 to handle if statement properly.
it can be fixed easily with another reverse at the end.